### PR TITLE
Dataflow: Fix bug of detecting definition of chained function

### DIFF
--- a/src/data-flow.ts
+++ b/src/data-flow.ts
@@ -555,6 +555,15 @@ class CallNamesListener implements ast.WalkListener {
     if (type == ast.NAME) {
       for (let ancestor of ancestors) {
         if (this._subtreesToProcess.indexOf(ancestor) !== -1) {
+          /*
+           * Don't include names of functions.
+           */
+          if (ancestors.length > 1) {
+            let parent = ancestors[ancestors.length - 2];
+            if (parent.type == ast.CALL && parent.func == node) {
+              break;
+            }
+          }
           this.defs.add({
             type: SymbolType.MUTATION,
             level: ReferenceType.UPDATE,

--- a/src/test/analysis.test.ts
+++ b/src/test/analysis.test.ts
@@ -350,6 +350,11 @@ describe('getDefs', () => {
       let defs = getDefNamesFromStatement('a + func()');
       expect(defs).to.deep.equal([]);
     });
+		
+    it('for functions called early in a call chain', () => {
+      let defs = getDefNamesFromStatement('func().func()');
+      expect(defs).to.deep.equal([]);
+    });
   });
 });
 


### PR DESCRIPTION
To my knowledge, this fix should help reduce the overly conservative slice from https://github.com/microsoft/gather/pull/33 back to its expected size.

The behavior before was that all names that were children of a function call node would be considered "defined"---including arguments, objects the function is called on, and function names that appear earlier in the chain.

The desired behavior is that the names of functions that appear earlier in a chain should not be considered "defined." That's what this fix fixes.